### PR TITLE
Blur support for themes.

### DIFF
--- a/TMessagesProj/src/main/assets/arctic.attheme
+++ b/TMessagesProj/src/main/assets/arctic.attheme
@@ -323,3 +323,4 @@ chat_serviceText=-1
 chats_attachMessage=-13268780
 key_changephoneinfo_changeText=-13131798
 chat_outSentClock=1895825407
+chat_BlurAlpha=-771751936

--- a/TMessagesProj/src/main/assets/bluebubbles.attheme
+++ b/TMessagesProj/src/main/assets/bluebubbles.attheme
@@ -185,3 +185,4 @@ chat_outReplyMediaMessageSelectedText=-8674357
 chats_attachMessage=-14843710
 chat_outSentClock=-594761027
 chat_searchPanelText=-12609056
+chat_BlurAlpha=-771751936

--- a/TMessagesProj/src/main/assets/darkblue.attheme
+++ b/TMessagesProj/src/main/assets/darkblue.attheme
@@ -467,3 +467,4 @@ chat_outSentClock=-8213557
 dialogBackgroundGray=-14932431
 chat_searchPanelText=-8796932
 chat_inContactIcon=-1
+chat_BlurAlpha=-771751936

--- a/TMessagesProj/src/main/assets/day.attheme
+++ b/TMessagesProj/src/main/assets/day.attheme
@@ -352,3 +352,4 @@ chat_serviceText=-13092808
 chats_attachMessage=-14321214
 key_changephoneinfo_changeText=-13131798
 chat_outSentClock=1895825407
+chat_BlurAlpha=-771751936

--- a/TMessagesProj/src/main/assets/graphite.attheme
+++ b/TMessagesProj/src/main/assets/graphite.attheme
@@ -462,3 +462,4 @@ chat_outSentClock=-7161633
 dialogBackgroundGray=-13618631
 chat_searchPanelText=-7752465
 chat_inContactIcon=-1
+chat_BlurAlpha=-771751936

--- a/TMessagesProj/src/main/assets/vkdark.attheme
+++ b/TMessagesProj/src/main/assets/vkdark.attheme
@@ -603,3 +603,4 @@ chat_outSentClock=-9327893
 dialogBackgroundGray=-16777216
 chat_searchPanelText=-9999761
 chat_inContactIcon=-1
+chat_BlurAlpha=-771751936

--- a/TMessagesProj/src/main/assets/vkold.attheme
+++ b/TMessagesProj/src/main/assets/vkold.attheme
@@ -299,3 +299,4 @@ chat_outInstant=-11370056
 chat_outSentClock=-6182221
 chat_searchPanelText=-11370056
 chat_inContactIcon=-1
+chat_BlurAlpha=-771751936


### PR DESCRIPTION
Added string to theme's for enabling the new blur effect introduced in 8.5 telegram update.
Could possibly be broken for the Graphite and Dark theme, so please compile and release as a test build first.